### PR TITLE
Add docs for finance summary and AI chat

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -29,6 +29,9 @@ PLAID_WEBHOOK_SECRET=optional_webhook_secret_for_production
 
 # OpenAI API (optional)
 OPENAI_API_KEY=your_openai_api_key
+# Custom LLM (optional)
+LLM_API_URL=https://s5rs0cklk8.execute-api.us-east-1.amazonaws.com/Prod/v1/chat/completions
+LLM_API_TOKEN=your_llm_token
 
 # Frontend
 REACT_APP_API_URL=http://localhost:8000/api

--- a/README.md
+++ b/README.md
@@ -10,8 +10,10 @@ A secure full-stack application that connects to financial accounts via Plaid, c
 - **Transaction Categorization**: Basic categorization with optional AI-assisted labeling
 - **Account Dashboard**: View all accounts and balances in one place
 - **Transaction Management**: View, search, and sort your transactions
+- **Financial Summary**: See budgets, assets, and net worth at a glance
 - **Secure API**: Well-designed backend with proper security controls
 - **Dockerized Environment**: Easy local development and deployment
+- **AI Chat**: Ask natural language questions about your finances
 
 ## Technology Stack
 
@@ -30,6 +32,7 @@ A secure full-stack application that connects to financial accounts via Plaid, c
 - JWT-based authentication
 - Plaid API integration
 - OpenAI API for transaction categorization
+- Optional LLM service for AI-powered chat
 
 ### Infrastructure
 - Docker containers for consistent development and deployment
@@ -90,7 +93,11 @@ finance-app/
 - Node.js (v18+)
 - Docker and Docker Compose
 - Plaid Developer Account (free Sandbox tier is sufficient to start)
-- OpenAI API Key (optional for LLM transaction categorization)
+- OpenAI API Key (optional for transaction categorization)
+- LLM_API_URL and LLM_API_TOKEN if using the built-in chat feature
+
+Set `LLM_API_URL` to the endpoint of your language model service and
+`LLM_API_TOKEN` to the associated bearer token.
 
 ### Setting Up Plaid API Access (Required)
 

--- a/backend/src/controllers/chat.controller.ts
+++ b/backend/src/controllers/chat.controller.ts
@@ -1,0 +1,42 @@
+import { Request, Response, NextFunction } from 'express';
+import { askQuestion } from '../config/openai';
+import { Account, Asset, Transaction } from '../models';
+import { logger } from '../utils/logger';
+
+export const askFinanceQuestion = async (req: Request, res: Response, next: NextFunction) => {
+  try {
+    const userId = (req as any).user.id;
+    const { question } = req.body;
+    if (!question) {
+      return res.status(400).json({ error: 'Question is required' });
+    }
+
+    const accounts = await Account.findAll({ where: { userId } });
+    const assets = await Asset.findAll({ where: { userId } });
+    const transactions = await Transaction.findAll({
+      where: { userId },
+      order: [['date', 'DESC']],
+      limit: 100,
+    });
+
+    const summary = {
+      accounts: accounts.map(a => ({ name: a.name, balance: a.currentBalance })),
+      assets: assets.map(a => ({ name: a.name, value: a.value })),
+      transactions: transactions.map(t => ({
+        date: t.date,
+        name: t.name,
+        amount: t.amount,
+        category: t.getEffectiveCategory(),
+      })),
+    };
+
+    const prompt = `You are a helpful personal finance assistant. Answer the user's question based on their data.\nUser question: ${question}\nUser data: ${JSON.stringify(summary)}`;
+
+    logger.debug('Sending prompt to OpenAI', { prompt });
+    const answer = await askQuestion(prompt);
+
+    res.status(200).json({ answer });
+  } catch (error) {
+    next(error);
+  }
+};

--- a/backend/src/controllers/summary.controller.ts
+++ b/backend/src/controllers/summary.controller.ts
@@ -1,0 +1,39 @@
+import { Request, Response, NextFunction } from 'express';
+import { Account, Asset, Budget, Transaction } from '../models';
+
+export const getFinancialSummary = async (req: Request, res: Response, next: NextFunction) => {
+  try {
+    const userId = (req as any).user.id;
+
+    const [accounts, assets, budgets, transactions] = await Promise.all([
+      Account.findAll({ where: { userId } }),
+      Asset.findAll({ where: { userId } }),
+      Budget.findAll({ where: { userId, isActive: true } }),
+      Transaction.findAll({ where: { userId } })
+    ]);
+
+    // Net worth calculations
+    const accountBalance = accounts.reduce((sum, a) => sum + Number(a.currentBalance || 0), 0);
+    const assetValue = assets.reduce((sum, a) => sum + Number(a.value || 0), 0);
+    const netWorth = accountBalance + assetValue;
+
+    // Spending by category
+    const spendingByCategory: Record<string, number> = {};
+    transactions.forEach(t => {
+      if (t.amount > 0) {
+        const cat = t.getEffectiveCategory();
+        spendingByCategory[cat] = (spendingByCategory[cat] || 0) + Number(t.amount);
+      }
+    });
+
+    res.status(200).json({
+      accounts: accountBalance,
+      assets: assetValue,
+      netWorth,
+      budgets,
+      spendingByCategory
+    });
+  } catch (error) {
+    next(error);
+  }
+};

--- a/backend/src/controllers/transaction.controller.ts
+++ b/backend/src/controllers/transaction.controller.ts
@@ -235,7 +235,7 @@ export const getMonthlyStats = async (req: Request, res: Response, next: NextFun
             WHEN "llmCategory" IS NOT NULL THEN "llmCategory"
             ELSE "category"
           END
-        `),
+        `) as any,
       ],
       order: [[Sequelize.fn('SUM', Sequelize.col('amount')), 'DESC']],
       limit: 5,
@@ -324,7 +324,7 @@ export const getSpendingByCategory = async (req: Request, res: Response, next: N
             WHEN "llmCategory" IS NOT NULL THEN "llmCategory"
             ELSE "category"
           END
-        `),
+        `) as any,
       ],
       order: [[Sequelize.fn('SUM', Sequelize.col('amount')), 'DESC']],
     });

--- a/backend/src/routes/chat.routes.ts
+++ b/backend/src/routes/chat.routes.ts
@@ -1,0 +1,9 @@
+import express from 'express';
+import { authenticate } from '../middleware/auth.middleware';
+import { askFinanceQuestion } from '../controllers/chat.controller';
+
+const router = express.Router();
+router.use(authenticate);
+router.post('/', askFinanceQuestion);
+
+export default router;

--- a/backend/src/routes/summary.routes.ts
+++ b/backend/src/routes/summary.routes.ts
@@ -1,0 +1,9 @@
+import express from 'express';
+import { authenticate } from '../middleware/auth.middleware';
+import { getFinancialSummary } from '../controllers/summary.controller';
+
+const router = express.Router();
+router.use(authenticate);
+router.get('/', getFinancialSummary);
+
+export default router;

--- a/backend/src/server.ts
+++ b/backend/src/server.ts
@@ -18,6 +18,8 @@ import categoryRoutes from './routes/category.routes';
 import assetRoutes from './routes/asset.routes';
 import budgetRoutes from './routes/budget.routes';
 import plaidRoutes from './routes/plaid.routes';
+import summaryRoutes from './routes/summary.routes';
+import chatRoutes from './routes/chat.routes';
 
 // Create Express server
 const app = express();
@@ -50,6 +52,8 @@ app.use('/api/categories', categoryRoutes);
 app.use('/api/assets', assetRoutes);
 app.use('/api/budgets', budgetRoutes);
 app.use('/api/plaid', plaidRoutes);
+app.use('/api/summary', summaryRoutes);
+app.use('/api/chat', chatRoutes);
 
 // Health check
 app.get('/health', (req: Request, res: Response) => {

--- a/docs/api.md
+++ b/docs/api.md
@@ -728,6 +728,46 @@ DELETE /budgets/:id
 }
 ```
 
+### Financial summary
+
+```
+GET /summary
+```
+
+**Response:**
+```json
+{
+  "accounts": 1234.56,
+  "assets": 2500.00,
+  "netWorth": 3734.56,
+  "budgets": [/* active budgets */],
+  "spendingByCategory": {
+    "Food": 200.12,
+    "Transportation": 75.00
+  }
+}
+```
+
+### AI chat
+
+```
+POST /chat
+```
+
+**Request Body:**
+```json
+{
+  "question": "How much did I spend on groceries this month?"
+}
+```
+
+**Response:**
+```json
+{
+  "answer": "You spent $200.12 on groceries this month."
+}
+```
+
 ## Error Responses
 
 ### Standard Error Format


### PR DESCRIPTION
## Summary
- fix environment variable loading order for custom LLM
- document financial summary and chat endpoints
- highlight the financial summary feature in README
- note how to configure LLM API URL and token

## Testing
- `npm run build --prefix backend`
- `npm test --prefix backend` *(fails: SequelizeConnectionRefusedError)*

------
https://chatgpt.com/codex/tasks/task_e_68410a6aa28c832f8df8f73cc6c3c6e6